### PR TITLE
Default tcp health probes not set for GPU apps

### DIFF
--- a/articles/container-apps/health-probes.md
+++ b/articles/container-apps/health-probes.md
@@ -162,7 +162,7 @@ The optional `failureThreshold` setting defines the number of attempts Container
 
 ## Default configuration
 
-If ingress is enabled, the following default probes are automatically added to the main app container if none is defined for each type.
+If ingress is enabled, the following default probes are automatically added to the main app container if none is defined for each type, except for GPU workload profiles (both dedicated and consumption).
 
 | Probe type | Default values |
 | -- | -- |


### PR DESCRIPTION
Update text to call out that GPU apps don't get default probes